### PR TITLE
Update _squash_responses()

### DIFF
--- a/fireREST/__init__.py
+++ b/fireREST/__init__.py
@@ -186,7 +186,7 @@ class Client(object):
             return responses[0].json()
         items = list()
         for response in responses:
-            if 'items' in response:
+            if 'items' in response.json():
                 items.extend(response.json()['items'])
             else:
                 self.logger.debug('Response {response.url} did not contain any items. Skipping...')


### PR DESCRIPTION
 _squash_responses() erroneously generates debug message "did not contain any items. Skipping..." when passes multiple pages of responses.